### PR TITLE
Add debug="when_hidden" option.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -235,11 +235,11 @@ Your users must have JavaScript enabled for this shortcode to work.
 
 **The timed-content-server shortcode**
 
-`[timed-content-server show="datetime" hide="datetime" debug="true|false"]Example Text[/timed-content-server]`
+`[timed-content-server show="datetime" hide="datetime" debug="true|false|when_hidden"]Example Text[/timed-content-server]`
 
 * `show` - Specifies the date/time when the marked content should start being included on the web page.
 * `hide` - Specifies the date/time after which the marked content should stop being included on the web page.
-* `debug` - If `true`, adds some debugging statements to the web page as HTML comments. Defaults to `false`.
+* `debug` - If `true`, adds some debugging statements to the web page as HTML comments. If `when_hidden`, the debugging statements are added only when the content is hidden. Defaults to `false`.
 
 The date and time are expected to be yyyy-mm-dd HH:MM (similar to ISO 8601), for example `2019-04-07 15:30` for April 7, 2019, 15:30. For backward compatiblity old "human readable" date formats should also work, but these should not be used any longer!
 

--- a/timed-content.php
+++ b/timed-content.php
@@ -1469,7 +1469,8 @@ class timedContentPlugin
             $show_content = true;
         }
 
-        if ( ( $debug == "true" ) && ( current_user_can( "edit_post", $post->post_id ) ) ) {
+        if ( ( ( $debug == "true" ) || ( ( ! $show_content ) && ( $debug == "when_hidden" ) ) )
+                && ( current_user_can( "edit_post", $post->post_id ) ) ) {
             add_filter( 'date_i18n', array( &$this, "fix_date_i18n" ), 10, 4 );
             $temp_tz = date_default_timezone_get();
             date_default_timezone_set( get_option( 'timezone_string' ) );


### PR DESCRIPTION
By setting the shortcode variable `debug` to `"when_hidden"`, the
debugging statements will only be added to the page when the content is
hidden by the plugin.

By doing this, anyone that can edit the page can have a clear view of
what will be published and when, without having to deal with multiple
debugging statements for already displayed content.