### PR TITLE
Show not sanitized timed content in debug

### DIFF
--- a/timed-content.php
+++ b/timed-content.php
@@ -1522,7 +1522,7 @@ class timedContentPlugin
             $debug_message .= "<p>" . __( 'Current date:',
                     'timed-content' ) . "&nbsp;" . $right_now . "</p>\n";
             $debug_message .= "<p>" . __( 'Content filter:', 'timed-content' ) . "&nbsp;" . $the_filter . "</p>\n";
-            $debug_message .= "<p>" . _x( 'Content:', "Noun", 'timed-content' ) . "</p><p><code>" . htmlspecialchars($content) . "</code></p>\n";
+            $debug_message .= "<p>" . _x( 'Content:', "Noun", 'timed-content' ) . "</p><p>" . $content . "</p>\n";
 
             if ( $show_content === true ) {
                 $debug_message .= "<p>" . __( 'The plugin will show the content.', 'timed-content' ) . "</p>";


### PR DESCRIPTION
The use of `htmlspecialchars` in the debug message has the advantage of
never breaking the layout of the debug message itself. However it is
hard to have an understanding of the final result. This commit
re-introduces the previous timed-content debug message behavior of
showing the content without sanitization.